### PR TITLE
disable backend usage

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -104,11 +104,11 @@
         "branch": "19.02"
       }
     },
-    "upload_skill_manifest": true,
+    "upload_skill_manifest": false,
     // Directory to look for user skills
     "directory": "~/.mycroft/skills",
     // Enable auto update by msm
-    "auto_update": true,
+    "auto_update": false,
     // blacklisted skills to not load
     // NB: This is the basename() of the directory where the skill lives, so if
     // the skill you want to blacklist is in /opt/mycroft/skills/mycroft-alarm.mycroftai/
@@ -122,10 +122,11 @@
 
   // Address of the REMOTE server
   "server": {
-    "url": "https://api.mycroft.ai",
-    "version": "v1",
-    "update": true,
-    "metrics": false
+    "url": "http://0.0.0.0:6712",
+    "version": "v0.1",
+    "update": false,
+    "metrics": false,
+    "disabled": true
   },
 
   // The mycroft-core messagebus websocket
@@ -155,7 +156,7 @@
     // /tmp/mycroft_utterance<TIMESTAMP>.wav
     "save_utterances": false,
     "wake_word_upload": {
-      "disable": false,
+      "disable": true,
       "url": "https://training.mycroft.ai/precise/upload"
     },
 

--- a/mycroft/metrics/__init__.py
+++ b/mycroft/metrics/__init__.py
@@ -18,7 +18,7 @@ import time
 
 import requests
 
-from mycroft.api import DeviceApi, is_paired
+from mycroft.api import DeviceApi, is_paired, is_disabled
 from mycroft.configuration import Configuration
 from mycroft.session import SessionManager
 from mycroft.util.log import LOG
@@ -34,6 +34,8 @@ def report_metric(name, data):
         name (str): Name of metric. Must use only letters and hyphens
         data (dict): JSON dictionary to report. Must be valid JSON
     """
+    if is_disabled():
+        return
     try:
         if is_paired() and Configuration().get()['opt_in']:
             DeviceApi().report_metric(name, data)
@@ -172,6 +174,8 @@ class MetricsPublisher:
         conf = Configuration().get()['server']
         self.url = url or conf['url']
         self.enabled = enabled or conf['metrics']
+        if conf.get("disabled", True):
+            self.enabled = False
 
     def publish(self, events):
         if 'session_id' not in events:


### PR DESCRIPTION
## Description

You can disable backend globally by setting "disabled" to False

```json
  "server": {
    "url": "http://0.0.0.0:6712",
    "version": "v0.1",
    "update": false,
    "metrics": false,
    "disabled": true
  }
```

utility method

```python
from mycroft.api import is_disabled

if not is_disabled():
    print("404 privacy not found")
```

