### PR TITLE
google stt

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -252,7 +252,7 @@
   "stt": {
     // Engine.  Options: "mycroft", "google", "wit", "ibm", "kaldi", "bing",
     //                   "houndify", "deepspeech_server", "govivace"
-    "module": "mycroft"
+    "module": "google"
     // "deepspeech_server": {
     //   "uri": "http://localhost:8080/stt"
     // },

--- a/mycroft/stt/__init__.py
+++ b/mycroft/stt/__init__.py
@@ -84,6 +84,8 @@ class KeySTT(STT):
 class GoogleSTT(TokenSTT):
     def __init__(self):
         super(GoogleSTT, self).__init__()
+        # allow None to use demo key by default
+        self.token = self.credential.get("token")
 
     def execute(self, audio, language=None):
         self.lang = language or self.lang


### PR DESCRIPTION
since #5 disables backend by default STT will not work 

makes google the default module and takes advantage of the demo google key from [speech_recognition](https://github.com/Uberi/speech_recognition/blob/master/speech_recognition/__init__.py#L870) package