### PR TITLE
feat/target bus messages

### DIFF
--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -50,6 +50,13 @@ def handle_speak(event):
     Configuration.init(bus)
     global _last_stop_signal
 
+    # if the message is targeted and audio is not the target don't
+    # don't synthezise speech
+    if (event.context and 'destination' in event.context and
+            event.context['destination'] and
+            'audio' not in event.context['destination']):
+        return
+
     # Get conversation ID
     if event.context and 'ident' in event.context:
         ident = event.context['ident']

--- a/mycroft/client/speech/__main__.py
+++ b/mycroft/client/speech/__main__.py
@@ -60,7 +60,9 @@ def handle_wakeword(event):
 
 def handle_utterance(event):
     LOG.info("Utterance: " + str(event['utterances']))
-    context = {'client_name': 'mycroft_listener'}
+    context = {'client_name': 'mycroft_listener',
+               'source': 'audio',
+               'destination': None}
     if 'ident' in event:
         ident = event.pop('ident')
         context['ident'] = ident

--- a/mycroft/client/text/text_client.py
+++ b/mycroft/client/text/text_client.py
@@ -432,6 +432,11 @@ def handle_utterance(event):
     global chat
     global history
     utterance = event.data.get('utterances')[0]
+    # if the message is targeted and cli is not the target ignore utterance
+    if (event.context and 'destination' in event.context and
+            event.context['destination'] and
+            'cli' not in event.context['destination']):
+        return
     history.append(utterance)
     chat.append(utterance)
     set_screen_dirty()

--- a/mycroft/enclosure/api.py
+++ b/mycroft/enclosure/api.py
@@ -55,45 +55,54 @@ class EnclosureAPI:
         Typically this would be represented by the eyes being 'open'
         and the mouth reset to its default (smile or blank).
         """
-        self.bus.emit(Message("enclosure.reset"))
+        self.bus.emit(Message("enclosure.reset",
+                              context={"destination": "enclosure"}))
 
     def system_reset(self):
         """The enclosure hardware should reset any CPUs, etc."""
-        self.bus.emit(Message("enclosure.system.reset"))
+        self.bus.emit(Message("enclosure.system.reset",
+                              context={"destination": "enclosure"}))
 
     def system_mute(self):
         """Mute (turn off) the system speaker."""
-        self.bus.emit(Message("enclosure.system.mute"))
+        self.bus.emit(Message("enclosure.system.mute",
+                              context={"destination": "enclosure"}))
 
     def system_unmute(self):
         """Unmute (turn on) the system speaker."""
-        self.bus.emit(Message("enclosure.system.unmute"))
+        self.bus.emit(Message("enclosure.system.unmute",
+                              context={"destination": "enclosure"}))
 
     def system_blink(self, times):
         """The 'eyes' should blink the given number of times.
         Args:
             times (int): number of times to blink
         """
-        self.bus.emit(Message("enclosure.system.blink", {'times': times}))
+        self.bus.emit(Message("enclosure.system.blink", {'times': times},
+                              context={"destination": "enclosure"}))
 
     def eyes_on(self):
         """Illuminate or show the eyes."""
-        self.bus.emit(Message("enclosure.eyes.on"))
+        self.bus.emit(Message("enclosure.eyes.on",
+                              context={"destination": "enclosure"}))
 
     def eyes_off(self):
         """Turn off or hide the eyes."""
-        self.bus.emit(Message("enclosure.eyes.off"))
+        self.bus.emit(Message("enclosure.eyes.off",
+                              context={"destination": "enclosure"}))
 
     def eyes_blink(self, side):
         """Make the eyes blink
         Args:
             side (str): 'r', 'l', or 'b' for 'right', 'left' or 'both'
         """
-        self.bus.emit(Message("enclosure.eyes.blink", {'side': side}))
+        self.bus.emit(Message("enclosure.eyes.blink", {'side': side},
+                              context={"destination": "enclosure"}))
 
     def eyes_narrow(self):
         """Make the eyes look narrow, like a squint"""
-        self.bus.emit(Message("enclosure.eyes.narrow"))
+        self.bus.emit(Message("enclosure.eyes.narrow",
+                              context={"destination": "enclosure"}))
 
     def eyes_look(self, side):
         """Make the eyes look to the given side
@@ -104,7 +113,8 @@ class EnclosureAPI:
                         'd' for down
                         'c' for crossed
         """
-        self.bus.emit(Message("enclosure.eyes.look", {'side': side}))
+        self.bus.emit(Message("enclosure.eyes.look", {'side': side},
+                              context={"destination": "enclosure"}))
 
     def eyes_color(self, r=255, g=255, b=255):
         """Change the eye color to the given RGB color
@@ -114,7 +124,8 @@ class EnclosureAPI:
             b (int): 0-255, blue value
         """
         self.bus.emit(Message("enclosure.eyes.color",
-                              {'r': r, 'g': g, 'b': b}))
+                              {'r': r, 'g': g, 'b': b},
+                              context={"destination": "enclosure"}))
 
     def eyes_setpixel(self, idx, r=255, g=255, b=255):
         """Set individual pixels of the Mark 1 neopixel eyes
@@ -127,7 +138,8 @@ class EnclosureAPI:
         if idx < 0 or idx > 23:
             raise ValueError('idx ({}) must be between 0-23'.format(str(idx)))
         self.bus.emit(Message("enclosure.eyes.setpixel",
-                              {'idx': idx, 'r': r, 'g': g, 'b': b}))
+                              {'idx': idx, 'r': r, 'g': g, 'b': b},
+                              context={"destination": "enclosure"}))
 
     def eyes_fill(self, percentage):
         """Use the eyes as a type of progress meter
@@ -138,23 +150,27 @@ class EnclosureAPI:
             raise ValueError('percentage ({}) must be between 0-100'.
                              format(str(percentage)))
         self.bus.emit(Message("enclosure.eyes.fill",
-                              {'percentage': percentage}))
+                              {'percentage': percentage},
+                              context={"destination": "enclosure"}))
 
     def eyes_brightness(self, level=30):
         """Set the brightness of the eyes in the display.
         Args:
             level (int): 1-30, bigger numbers being brighter
         """
-        self.bus.emit(Message("enclosure.eyes.level", {'level': level}))
+        self.bus.emit(Message("enclosure.eyes.level", {'level': level},
+                              context={"destination": "enclosure"}))
 
     def eyes_reset(self):
         """Restore the eyes to their default (ready) state."""
-        self.bus.emit(Message("enclosure.eyes.reset"))
+        self.bus.emit(Message("enclosure.eyes.reset",
+                              context={"destination": "enclosure"}))
 
     def eyes_spin(self):
         """Make the eyes 'roll'
         """
-        self.bus.emit(Message("enclosure.eyes.spin"))
+        self.bus.emit(Message("enclosure.eyes.spin",
+                              context={"destination": "enclosure"}))
 
     def eyes_timed_spin(self, length):
         """Make the eyes 'roll' for the given time.
@@ -172,31 +188,37 @@ class EnclosureAPI:
         if volume < 0 or volume > 11:
             raise ValueError('volume ({}) must be between 0-11'.
                              format(str(volume)))
-        self.bus.emit(Message("enclosure.eyes.volume", {'volume': volume}))
+        self.bus.emit(Message("enclosure.eyes.volume", {'volume': volume},
+                              context={"destination": "enclosure"}))
 
     def mouth_reset(self):
         """Restore the mouth display to normal (blank)"""
-        self.bus.emit(Message("enclosure.mouth.reset"))
+        self.bus.emit(Message("enclosure.mouth.reset",
+                              context={"destination": "enclosure"}))
         self.display_manager.set_active(self.name)
 
     def mouth_talk(self):
         """Show a generic 'talking' animation for non-synched speech"""
-        self.bus.emit(Message("enclosure.mouth.talk"))
+        self.bus.emit(Message("enclosure.mouth.talk",
+                              context={"destination": "enclosure"}))
         self.display_manager.set_active(self.name)
 
     def mouth_think(self):
         """Show a 'thinking' image or animation"""
-        self.bus.emit(Message("enclosure.mouth.think"))
+        self.bus.emit(Message("enclosure.mouth.think",
+                              context={"destination": "enclosure"}))
         self.display_manager.set_active(self.name)
 
     def mouth_listen(self):
         """Show a 'thinking' image or animation"""
-        self.bus.emit(Message("enclosure.mouth.listen"))
+        self.bus.emit(Message("enclosure.mouth.listen",
+                              context={"destination": "enclosure"}))
         self.display_manager.set_active(self.name)
 
     def mouth_smile(self):
         """Show a 'smile' image or animation"""
-        self.bus.emit(Message("enclosure.mouth.smile"))
+        self.bus.emit(Message("enclosure.mouth.smile",
+                              context={"destination": "enclosure"}))
         self.display_manager.set_active(self.name)
 
     def mouth_viseme(self, start, viseme_pairs):
@@ -217,7 +239,8 @@ class EnclosureAPI:
                                  6 = shape for sounds like 'oy' or 'ao'
         """
         self.bus.emit(Message("enclosure.mouth.viseme_list",
-                              {"start": start, "visemes": viseme_pairs}))
+                              {"start": start, "visemes": viseme_pairs},
+                              context={"destination": "enclosure"}))
 
     def mouth_text(self, text=""):
         """Display text (scrolling as needed)
@@ -225,7 +248,8 @@ class EnclosureAPI:
             text (str): text string to display
         """
         self.display_manager.set_active(self.name)
-        self.bus.emit(Message("enclosure.mouth.text", {'text': text}))
+        self.bus.emit(Message("enclosure.mouth.text", {'text': text},
+                              context={"destination": "enclosure"}))
 
     def mouth_display(self, img_code="", x=0, y=0, refresh=True):
         """Display images on faceplate. Currently supports images up to 16x8,
@@ -245,7 +269,8 @@ class EnclosureAPI:
                               {'img_code': img_code,
                                'xOffset': x,
                                'yOffset': y,
-                               'clearPrev': refresh}))
+                               'clearPrev': refresh},
+                              context={"destination": "enclosure"}))
 
     def mouth_display_png(self, image_absolute_path,
                           invert=False, x=0, y=0, refresh=True):
@@ -267,7 +292,8 @@ class EnclosureAPI:
                                'xOffset': x,
                                'yOffset': y,
                                'invert': invert,
-                               'clearPrev': refresh}))
+                               'clearPrev': refresh},
+                              context={"destination": "enclosure"}))
 
     def weather_display(self, img_code, temp):
         """Show a the temperature and a weather icon
@@ -286,12 +312,15 @@ class EnclosureAPI:
         """
         self.display_manager.set_active(self.name)
         self.bus.emit(Message("enclosure.weather.display",
-                              {'img_code': img_code, 'temp': temp}))
+                              {'img_code': img_code, 'temp': temp},
+                              context={"destination": "enclosure"}))
 
     def activate_mouth_events(self):
         """Enable movement of the mouth with speech"""
-        self.bus.emit(Message('enclosure.mouth.events.activate'))
+        self.bus.emit(Message('enclosure.mouth.events.activate',
+                              context={"destination": "enclosure"}))
 
     def deactivate_mouth_events(self):
         """Disable movement of the mouth with speech"""
-        self.bus.emit(Message('enclosure.mouth.events.deactivate'))
+        self.bus.emit(Message('enclosure.mouth.events.deactivate',
+                              context={"destination": "enclosure"}))

--- a/mycroft/messagebus/message.py
+++ b/mycroft/messagebus/message.py
@@ -76,16 +76,34 @@ class Message:
                        obj.get('data') or {},
                        obj.get('context') or {})
 
+    def forward(self, type, data=None):
+        """ Keep context and forward message
+
+        This will take the same parameters as a message object but use
+        the current message object as a reference.  It will copy the context
+        from the existing message object.
+
+        Args:
+            type (str): type of message
+            data (dict): data for message
+            context: intented context for new message
+
+        Returns:
+            Message: Message object to be used on the reply to the message
+        """
+        data = data or {}
+        return Message(type, data, context=self.context)
+
     def reply(self, type, data=None, context=None):
         """Construct a reply message for a given message
 
         This will take the same parameters as a message object but use
         the current message object as a reference.  It will copy the context
         from the existing message object and add any context passed in to
-        the function.  Check for a target passed in to the function from
-        the data object and add that to the context as a target.  If the
-        context has a client name then that will become the target in the
-        context.  The new message will then have data passed in plus the
+        the function.  Check for a destination passed in to the function from
+        the data object and add that to the context as a destination.  If the
+        context has a source then that will be swapped with the destination
+        in the context.  The new message will then have data passed in plus the
         new context generated.
 
         Args:
@@ -102,10 +120,12 @@ class Message:
         new_context = self.context
         for key in context:
             new_context[key] = context[key]
-        if 'target' in data:
-            new_context['target'] = data['target']
-        elif 'client_name' in context:
-            context['target'] = context['client_name']
+        if 'destination' in data:
+            new_context['destination'] = data['destination']
+        if 'source' in new_context and 'destination' in new_context:
+            s = new_context['destination']
+            new_context['destination'] = new_context['source']
+            new_context['source'] = s
         return Message(type, data, context=new_context)
 
     def response(self, data=None, context=None):

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -1029,7 +1029,7 @@ class MycroftSkill:
                 if handler_info:
                     # Indicate that the skill handler is starting if requested
                     msg_type = handler_info + '.start'
-                    self.bus.emit(message.reply(msg_type, skill_data))
+                    self.bus.emit(message.forward(msg_type, skill_data))
 
                 if once:
                     # Remove registered one-time handler before invoking,
@@ -1056,7 +1056,7 @@ class MycroftSkill:
                 # Indicate that the skill handler has completed
                 if handler_info:
                     msg_type = handler_info + '.complete'
-                    self.bus.emit(message.reply(msg_type, skill_data))
+                    self.bus.emit(message.forward(msg_type, skill_data))
 
                 # Send timing metrics
                 context = message.context
@@ -1365,7 +1365,7 @@ class MycroftSkill:
                 'expect_response': expect_response}
         message = dig_for_message()
         if message:
-            self.bus.emit(message.reply("speak", data))
+            self.bus.emit(message.forward("speak", data))
         else:
             self.bus.emit(Message("speak", data))
         if wait:
@@ -1689,7 +1689,7 @@ class FallbackSkill(MycroftSkill):
 
         def handler(message):
             # indicate fallback handling start
-            bus.emit(message.reply("mycroft.skill.handler.start",
+            bus.emit(message.forward("mycroft.skill.handler.start",
                                    data={'handler': "fallback"}))
 
             stopwatch = Stopwatch()
@@ -1701,7 +1701,7 @@ class FallbackSkill(MycroftSkill):
                         if handler(message):
                             #  indicate completion
                             handler_name = get_handler_name(handler)
-                            bus.emit(message.reply(
+                            bus.emit(message.forward(
                                      'mycroft.skill.handler.complete',
                                      data={'handler': "fallback",
                                            "fallback_handler": handler_name}))
@@ -1709,11 +1709,11 @@ class FallbackSkill(MycroftSkill):
                     except Exception:
                         LOG.exception('Exception in fallback.')
                 else:  # No fallback could handle the utterance
-                    bus.emit(message.reply('complete_intent_failure'))
+                    bus.emit(message.forward('complete_intent_failure'))
                     warning = "No fallback could handle intent."
                     LOG.warning(warning)
                     #  indicate completion with exception
-                    bus.emit(message.reply('mycroft.skill.handler.complete',
+                    bus.emit(message.forward('mycroft.skill.handler.complete',
                                            data={'handler': "fallback",
                                                  'exception': warning}))
 


### PR DESCRIPTION
# Description
The speech handling now checks the message context if it's the intended target for the message and will only speak in the following conditions:

- Explicitly targeted i.e. the destination is "audio"
- destination is set to None
- destination is missing completely

The idea is that for example when the android app is used to access Mycroft the device at home shouldn't start to speak.

# Targeting Theory

The context target parameter in the original message can be set to list with any number of intended targets:

    bus.emit(Message('recognizer_loop:utterance', data, context={'destination': ['audio', 'kde']))

A missing destination or if the destination is set to None is interpreted as a multicast and should trigger all output capable processes (be it the mycroft-audio process, a web-interface, the KDE plasmoid or maybe the android app)

## Messages

the message.reply method will now swap "source" with "destination"

message now has a .forward method, this will keep previous context.

### Inside mycroft-core
- stt / cli will use "cli" or "audio" as source
- intent service will .reply to utterance message
- all skills messages are .forward from intent service .reply
- cli will check if "cli" is the destination
- audio will check if "audio" is the destination

## How to test

- STT utterances trigger TTS
- Cli utterances do not trigger TTS
